### PR TITLE
Update phys2bids tutorial link in ohbm23_tutorials.md

### DIFF
--- a/docs/ohbm23_tutorials.md
+++ b/docs/ohbm23_tutorials.md
@@ -15,10 +15,10 @@ Below are links to the materials to help you follow along with these tutorials.
 [Hands (and sensors!) on: a practical guide to acquiring your own physiological data -- Mary Miedema](#sensorsandbids)
 ----------------------------------------------------------------------------------------------------
 
-In this tutorial, we will show how to set up physiological recording and how to prepare such data for analysis, mainly by changing the format of proprietary file formats to [BIDS](https://bids.neuroimaging.io/) format.
+In this tutorial, we will show how to set up physiological recordings and how to prepare such data for analysis, mainly by changing the format of proprietary file formats to [BIDS](https://bids.neuroimaging.io/) format.
 
-[Docker](https://hub.docker.com/r/mmiedema/phys2bids_base)  
-[Sample Data](https://osf.io/3txqr/)
+All materials for this tutorial are available in the following repository:
+[Setup instructions, code, and link to data](https://github.com/m-miedema/ohbm2023phys2bidstutorial)
 
 
 [One person’s signal is another person's noise: hands-on tutorial to remove physiological fluctuations from MRI data -- Stefano Moia](#physasnoise)


### PR DESCRIPTION
Added updated link for phys2bids tutorial.

<!-- Add a short description of the PR content here-->

## Proposed Changes
  - Just changed a typo and my link on the OHBM tutorials page! I'll add a link to keep the Docker option in my repo's README.

## Change Type
- [ ] `bugfix`
- [ ] `refactoring`
- [ ] `infrastructure`
- [ ] `documentation`
- [x ] `other`

## Checklist before review
- [x ] I added everything I wanted to add to this PR.
- [x] \[Documentation only\] I built the docs locally.
- [x] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [x] My code respects the adopted style, especially linting conventions.
- [x] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [x] I added or indicated the right labels.
- [ ] I added information regarding the timeline of completion for this PR.
- [ ] Please, comment on my PR while it's a draft and give me feedback on the development!
